### PR TITLE
Fix SUM and AVG queries for postgres to return integers

### DIFF
--- a/src/Resources/JobsResource/Widgets/JobStatsOverview.php
+++ b/src/Resources/JobsResource/Widgets/JobStatsOverview.php
@@ -16,8 +16,8 @@ class JobStatsOverview extends BaseWidget
     {
         $aggregationColumns = [
             DB::raw('COUNT(*) as count'),
-            DB::raw('SUM(finished_at - started_at) as total_time_elapsed'),
-            DB::raw('AVG(finished_at - started_at) as average_time_elapsed'),
+            DB::raw($this->dbSum('finished_at', 'started_at').' as total_time_elapsed'),
+            DB::raw($this->dbAvg('finished_at', 'started_at').' as average_time_elapsed'),
         ];
 
         $aggregatedInfo = JobManager::query()
@@ -43,5 +43,24 @@ class JobStatsOverview extends BaseWidget
             Stat::make(__('jobs::translations.execution_time'), $totalTime),
             Stat::make(__('jobs::translations.average_time'), $averageTime),
         ];
+    }
+
+    private function dbAvg(string $col1, string $col2): string
+    {
+        return 'AVG('.$this->dbColumnAsInteger($col1).' - '.$this->dbColumnAsInteger($col2).')' . (DB::connection()->getConfig()['driver'] === 'pgsql' ? '::int' : '');
+    }
+
+    private function dbSum(string $col1, string $col2): string
+    {
+        return 'SUM('.$this->dbColumnAsInteger($col1).' - '.$this->dbColumnAsInteger($col2).')' . (DB::connection()->getConfig()['driver'] === 'pgsql' ? '::int' : '');
+    }
+
+    private function dbColumnAsInteger(string $colName): string
+    {
+        if (DB::connection()->getConfig()['driver'] === 'pgsql') {
+            return 'cast(extract(epoch from '.$colName.') as integer)';
+        }
+
+        return $colName;
     }
 }


### PR DESCRIPTION
Portgres will return these timestamp values as strings, eg "00:03" for 3 seconds, rather than ints. This leads to some pretty baffling errors (mine were indicating unrelated middlewares).

This PR casts those values to ints, only is the DB conn is Postgres.